### PR TITLE
Implement finger constructs

### DIFF
--- a/examples/listener.rs
+++ b/examples/listener.rs
@@ -23,7 +23,7 @@ impl leap::Listener for DemoListener {
         println!(
             "fps = {}, pointables = {}",
             frame.current_fps(),
-            frame.pointables().len()
+            frame.pointables().len(),
         );
         for pointable in frame.pointables().iter() {
             let stp = pointable.stabilized_tip_position();

--- a/examples/listener.rs
+++ b/examples/listener.rs
@@ -21,9 +21,10 @@ impl leap::Listener for DemoListener {
     fn on_frame(&mut self, controller: &Controller) {
         let frame = controller.frame();
         println!(
-            "fps = {}, pointables = {}",
+            "fps = {}, pointables = {}, fingers = {}",
             frame.current_fps(),
             frame.pointables().len(),
+            frame.fingers().len(),
         );
         for pointable in frame.pointables().iter() {
             let stp = pointable.stabilized_tip_position();
@@ -31,6 +32,17 @@ impl leap::Listener for DemoListener {
                 "[p]: id = {id}, td = {td:.1}, stp = ({x:.1}, {y:.1}, {z:.1})",
                 id = pointable.id(),
                 td = pointable.touch_distance(),
+                x = stp.x(),
+                y = stp.y(),
+                z = stp.z(),
+            );
+        }
+        for finger in frame.fingers().iter() {
+            let stp = finger.stabilized_tip_position();
+            println!(
+                "[f]: id = {id}, td = {td:.1}, stp = ({x:.1}, {y:.1}, {z:.1})",
+                id = finger.id(),
+                td = finger.touch_distance(),
                 x = stp.x(),
                 y = stp.y(),
                 z = stp.z(),

--- a/examples/listener.rs
+++ b/examples/listener.rs
@@ -29,23 +29,24 @@ impl leap::Listener for DemoListener {
         for pointable in frame.pointables().iter() {
             let stp = pointable.stabilized_tip_position();
             println!(
-                "[p]: id = {id}, td = {td:.1}, stp = ({x:.1}, {y:.1}, {z:.1})",
-                id = pointable.id(),
-                td = pointable.touch_distance(),
-                x = stp.x(),
-                y = stp.y(),
-                z = stp.z(),
+                "[p]: id = {}, td = {}, stp = ({}, {}, {})",
+                pointable.id(),
+                pointable.touch_distance(),
+                stp.x(),
+                stp.y(),
+                stp.z(),
             );
         }
         for finger in frame.fingers().iter() {
             let stp = finger.stabilized_tip_position();
             println!(
-                "[f]: id = {id}, td = {td:.1}, stp = ({x:.1}, {y:.1}, {z:.1})",
-                id = finger.id(),
-                td = finger.touch_distance(),
-                x = stp.x(),
-                y = stp.y(),
-                z = stp.z(),
+                "[f]: id = {}, type = {}, td = {}, stp = ({}, {}, {})",
+                finger.id(),
+                finger.type_enum(),
+                finger.touch_distance(),
+                stp.x(),
+                stp.y(),
+                stp.z(),
             );
         }
         println!("--------------------------------");

--- a/examples/listener.rs
+++ b/examples/listener.rs
@@ -19,6 +19,7 @@ impl leap::Listener for DemoListener {
     }
 
     fn on_frame(&mut self, controller: &Controller) {
+        // Get the frame, report information
         let frame = controller.frame();
         println!(
             "fps = {}, pointables = {}, fingers = {}",
@@ -26,6 +27,8 @@ impl leap::Listener for DemoListener {
             frame.pointables().len(),
             frame.fingers().len(),
         );
+
+        // Report all pointables (includes fingers)
         for pointable in frame.pointables().iter() {
             let stp = pointable.stabilized_tip_position();
             println!(
@@ -37,18 +40,22 @@ impl leap::Listener for DemoListener {
                 stp.z(),
             );
         }
+
+        // Report all fingers
         for finger in frame.fingers().iter() {
             let stp = finger.stabilized_tip_position();
             println!(
-                "[f]: id = {}, type = {}, td = {}, stp = ({}, {}, {})",
+                "[f]: id = {}, type = {}, extended = {}, td = {}, stp = ({}, {}, {})",
                 finger.id(),
                 finger.type_enum(),
+                finger.is_extended(),
                 finger.touch_distance(),
                 stp.x(),
                 stp.y(),
                 stp.z(),
             );
         }
+
         println!("--------------------------------");
         sleep_ms(150);
     }

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -1,5 +1,7 @@
-use raw;
 use std::os::raw::c_int;
+use std::fmt::{self, Display, Formatter};
+
+use raw;
 use Vector;
 
 pub struct Finger {
@@ -22,6 +24,19 @@ impl Finger {
 
     pub fn stabilized_tip_position(&self) -> Vector {
         unsafe { Vector::from_raw(raw::lm_finger_stabilized_tip_position(self.raw)) }
+    }
+
+    /// Get the finger type as enum
+    pub fn type_enum(&self) -> Type {
+        Type::from_id(self.type_id()).unwrap()
+    }
+
+    /// Get the finger ID
+    ///
+    /// The ID is defined by the Leap Motion SDK.
+    /// To use a Rust enum, take a look at the `take_enum` method instead.
+    pub fn type_id(&self) -> u8 {
+        unsafe { raw::lm_finger_type(self.raw) }
     }
 }
 
@@ -130,5 +145,76 @@ impl<'a> Iterator for Iter<'a> {
         } else {
             None
         }
+    }
+}
+
+/// Finger type
+#[derive(Copy, Clone)]
+pub enum Type {
+    /// The thumb
+    Thumb,
+
+    /// The index or fore-finger
+    Index,
+
+    /// The middle finger
+    Middle,
+
+    /// The ring finger
+    Ring,
+
+    /// The pinky or little finger
+    Pinky,
+}
+
+impl Type {
+    /// Get the finger type from the given `id`,
+    /// provided by the Leap Motion library.
+    ///
+    /// If the `id` is invalid, `None` is returned.
+    pub fn from_id(id: u8) -> Option<Self> {
+        match id {
+            0 => Some(Type::Thumb),
+            1 => Some(Type::Index),
+            2 => Some(Type::Middle),
+            3 => Some(Type::Ring),
+            4 => Some(Type::Pinky),
+            _ => None,
+        }
+    }
+
+    /// Get the finger type ID
+    pub fn id(&self) -> u8 {
+        match self {
+            Type::Thumb => 0,
+            Type::Index => 1,
+            Type::Middle => 2,
+            Type::Ring => 3,
+            Type::Pinky => 4,
+        }
+    }
+
+    /// Get the lowerface finger name
+    ///
+    /// It will be one of:
+    /// - `"thumb"`
+    /// - `"index"`
+    /// - `"middle"`
+    /// - `"ring"`
+    /// - `"pinky"`
+    pub fn name(&self) -> &'static str {
+        match self {
+            Type::Thumb => "thumb",
+            Type::Index => "index",
+            Type::Middle => "middle",
+            Type::Ring => "ring",
+            Type::Pinky => "pinky",
+        }
+    }
+}
+
+impl Display for Type {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.name())
     }
 }

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -38,6 +38,10 @@ impl Finger {
     pub fn type_id(&self) -> u32 {
         unsafe { raw::lm_finger_type(self.raw) }
     }
+
+    pub fn is_extended(&self) -> bool {
+        unsafe { raw::lm_finger_is_extended(self.raw) }
+    }
 }
 
 impl Drop for Finger {
@@ -63,6 +67,10 @@ impl FingerList {
 
     pub fn is_empty(&self) -> bool {
         unsafe { raw::lm_finger_list_is_empty(self.raw) }
+    }
+
+    pub fn extended(&self) -> FingerList {
+        unsafe { FingerList::from_raw(raw::lm_finger_list_extended(self.raw)) }
     }
 
     pub fn frontmost(&self) -> Option<Finger> {

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -35,7 +35,7 @@ impl Finger {
     ///
     /// The ID is defined by the Leap Motion SDK.
     /// To use a Rust enum, take a look at the `take_enum` method instead.
-    pub fn type_id(&self) -> u8 {
+    pub fn type_id(&self) -> u32 {
         unsafe { raw::lm_finger_type(self.raw) }
     }
 }
@@ -172,7 +172,7 @@ impl Type {
     /// provided by the Leap Motion library.
     ///
     /// If the `id` is invalid, `None` is returned.
-    pub fn from_id(id: u8) -> Option<Self> {
+    pub fn from_id(id: u32) -> Option<Self> {
         match id {
             0 => Some(Type::Thumb),
             1 => Some(Type::Index),
@@ -184,7 +184,7 @@ impl Type {
     }
 
     /// Get the finger type ID
-    pub fn id(&self) -> u8 {
+    pub fn id(&self) -> u32 {
         match self {
             Type::Thumb => 0,
             Type::Index => 1,

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -1,0 +1,94 @@
+use raw;
+use std::os::raw::c_int;
+use Vector;
+
+pub struct Finger {
+    raw: *mut raw::Finger,
+}
+
+impl Finger {
+    pub unsafe fn from_raw(raw: *mut raw::Finger) -> Finger {
+        Finger { raw }
+    }
+
+    /// returned id might be negative
+    pub fn id(&self) -> i32 {
+        unsafe { raw::lm_finger_id(self.raw) }
+    }
+
+    pub fn touch_distance(&self) -> f32 {
+        unsafe { raw::lm_finger_touch_distance(self.raw) }
+    }
+
+    pub fn stabilized_tip_position(&self) -> Vector {
+        unsafe { Vector::from_raw(raw::lm_finger_stabilized_tip_position(self.raw)) }
+    }
+}
+
+impl Drop for Finger {
+    fn drop(&mut self) {
+        unsafe {
+            raw::lm_finger_delete(self.raw);
+        }
+    }
+}
+
+pub struct FingerList {
+    raw: *mut raw::FingerList,
+}
+
+impl FingerList {
+    pub unsafe fn from_raw(raw: *mut raw::FingerList) -> FingerList {
+        FingerList { raw }
+    }
+
+    // TODO: pub fn len(&self) -> usize {
+    // TODO:     unsafe { raw::lm_finger_list_count(self.raw) as usize }
+    // TODO: }
+
+    // TODO: pub fn get(&self, index: usize) -> Option<Finger> {
+    // TODO:     unsafe {
+    // TODO:         if index < self.len() {
+    // TODO:             Some(Finger::from_raw(raw::lm_finger_list_at(
+    // TODO:                 self.raw,
+    // TODO:                 index as c_int,
+    // TODO:             )))
+    // TODO:         } else {
+    // TODO:             None
+    // TODO:         }
+    // TODO:     }
+    // TODO: }
+
+    pub fn iter(&self) -> Iter {
+        Iter {
+            list: self,
+            index: 0,
+        }
+    }
+}
+
+impl Drop for FingerList {
+    fn drop(&mut self) {
+        unsafe {
+            raw::lm_finger_list_delete(self.raw);
+        }
+    }
+}
+
+pub struct Iter<'a> {
+    list: &'a FingerList,
+    index: usize,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = Finger;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO: if let Some(finger) = self.list.get(self.index) {
+        // TODO:     self.index += 1;
+        // TODO:     Some(finger)
+        // TODO: } else {
+            None
+        // TODO: }
+    }
+}

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -27,8 +27,8 @@ impl Finger {
     }
 
     /// Get the finger type as enum
-    pub fn type_enum(&self) -> Type {
-        Type::from_id(self.type_id()).unwrap()
+    pub fn type_enum(&self) -> FingerType {
+        FingerType::from_id(self.type_id()).unwrap()
     }
 
     /// Get the finger ID
@@ -67,6 +67,14 @@ impl FingerList {
 
     pub fn is_empty(&self) -> bool {
         unsafe { raw::lm_finger_list_is_empty(self.raw) }
+    }
+
+    pub fn finger_type(&self, finger_type: FingerType) -> FingerList {
+        self.finger_type_id(finger_type.id())
+    }
+
+    fn finger_type_id(&self, finger_type: u32) -> FingerList {
+        unsafe { FingerList::from_raw(raw::lm_finger_list_finger_type(self.raw, finger_type)) }
     }
 
     pub fn extended(&self) -> FingerList {
@@ -152,7 +160,7 @@ impl<'a> Iterator for Iter<'a> {
 
 /// Finger type
 #[derive(Copy, Clone)]
-pub enum Type {
+pub enum FingerType {
     /// The thumb
     Thumb,
 
@@ -169,18 +177,18 @@ pub enum Type {
     Pinky,
 }
 
-impl Type {
+impl FingerType {
     /// Get the finger type from the given `id`,
     /// provided by the Leap Motion library.
     ///
     /// If the `id` is invalid, `None` is returned.
     pub fn from_id(id: u32) -> Option<Self> {
         match id {
-            0 => Some(Type::Thumb),
-            1 => Some(Type::Index),
-            2 => Some(Type::Middle),
-            3 => Some(Type::Ring),
-            4 => Some(Type::Pinky),
+            0 => Some(FingerType::Thumb),
+            1 => Some(FingerType::Index),
+            2 => Some(FingerType::Middle),
+            3 => Some(FingerType::Ring),
+            4 => Some(FingerType::Pinky),
             _ => None,
         }
     }
@@ -188,11 +196,11 @@ impl Type {
     /// Get the finger type ID
     pub fn id(&self) -> u32 {
         match self {
-            Type::Thumb => 0,
-            Type::Index => 1,
-            Type::Middle => 2,
-            Type::Ring => 3,
-            Type::Pinky => 4,
+            FingerType::Thumb => 0,
+            FingerType::Index => 1,
+            FingerType::Middle => 2,
+            FingerType::Ring => 3,
+            FingerType::Pinky => 4,
         }
     }
 
@@ -206,16 +214,16 @@ impl Type {
     /// - `"pinky"`
     pub fn name(&self) -> &'static str {
         match self {
-            Type::Thumb => "thumb",
-            Type::Index => "index",
-            Type::Middle => "middle",
-            Type::Ring => "ring",
-            Type::Pinky => "pinky",
+            FingerType::Thumb => "thumb",
+            FingerType::Index => "index",
+            FingerType::Middle => "middle",
+            FingerType::Ring => "ring",
+            FingerType::Pinky => "pinky",
         }
     }
 }
 
-impl Display for Type {
+impl Display for FingerType {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.name())
     }

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -1,5 +1,5 @@
-use std::os::raw::c_int;
 use std::fmt::{self, Display, Formatter};
+use std::os::raw::c_int;
 
 use raw;
 use Vector;
@@ -70,9 +70,7 @@ impl FingerList {
             if self.is_empty() {
                 None
             } else {
-                Some(Finger::from_raw(raw::lm_finger_list_frontmost(
-                    self.raw,
-                )))
+                Some(Finger::from_raw(raw::lm_finger_list_frontmost(self.raw)))
             }
         }
     }
@@ -82,9 +80,7 @@ impl FingerList {
             if self.is_empty() {
                 None
             } else {
-                Some(Finger::from_raw(raw::lm_finger_list_leftmost(
-                    self.raw,
-                )))
+                Some(Finger::from_raw(raw::lm_finger_list_leftmost(self.raw)))
             }
         }
     }
@@ -94,9 +90,7 @@ impl FingerList {
             if self.is_empty() {
                 None
             } else {
-                Some(Finger::from_raw(raw::lm_finger_list_rightmost(
-                    self.raw,
-                )))
+                Some(Finger::from_raw(raw::lm_finger_list_rightmost(self.raw)))
             }
         }
     }

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -62,6 +62,30 @@ impl FingerList {
         }
     }
 
+    pub fn leftmost(&self) -> Option<Finger> {
+        unsafe {
+            if self.is_empty() {
+                None
+            } else {
+                Some(Finger::from_raw(raw::lm_finger_list_leftmost(
+                    self.raw,
+                )))
+            }
+        }
+    }
+
+    pub fn rightmost(&self) -> Option<Finger> {
+        unsafe {
+            if self.is_empty() {
+                None
+            } else {
+                Some(Finger::from_raw(raw::lm_finger_list_rightmost(
+                    self.raw,
+                )))
+            }
+        }
+    }
+
     pub fn get(&self, index: usize) -> Option<Finger> {
         unsafe {
             if index < self.len() {

--- a/src/finger.rs
+++ b/src/finger.rs
@@ -42,22 +42,38 @@ impl FingerList {
         FingerList { raw }
     }
 
-    // TODO: pub fn len(&self) -> usize {
-    // TODO:     unsafe { raw::lm_finger_list_count(self.raw) as usize }
-    // TODO: }
+    pub fn len(&self) -> usize {
+        unsafe { raw::lm_finger_list_count(self.raw) as usize }
+    }
 
-    // TODO: pub fn get(&self, index: usize) -> Option<Finger> {
-    // TODO:     unsafe {
-    // TODO:         if index < self.len() {
-    // TODO:             Some(Finger::from_raw(raw::lm_finger_list_at(
-    // TODO:                 self.raw,
-    // TODO:                 index as c_int,
-    // TODO:             )))
-    // TODO:         } else {
-    // TODO:             None
-    // TODO:         }
-    // TODO:     }
-    // TODO: }
+    pub fn is_empty(&self) -> bool {
+        unsafe { raw::lm_finger_list_is_empty(self.raw) }
+    }
+
+    pub fn frontmost(&self) -> Option<Finger> {
+        unsafe {
+            if self.is_empty() {
+                None
+            } else {
+                Some(Finger::from_raw(raw::lm_finger_list_frontmost(
+                    self.raw,
+                )))
+            }
+        }
+    }
+
+    pub fn get(&self, index: usize) -> Option<Finger> {
+        unsafe {
+            if index < self.len() {
+                Some(Finger::from_raw(raw::lm_finger_list_at(
+                    self.raw,
+                    index as c_int,
+                )))
+            } else {
+                None
+            }
+        }
+    }
 
     pub fn iter(&self) -> Iter {
         Iter {
@@ -84,11 +100,11 @@ impl<'a> Iterator for Iter<'a> {
     type Item = Finger;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO: if let Some(finger) = self.list.get(self.index) {
-        // TODO:     self.index += 1;
-        // TODO:     Some(finger)
-        // TODO: } else {
+        if let Some(finger) = self.list.get(self.index) {
+            self.index += 1;
+            Some(finger)
+        } else {
             None
-        // TODO: }
+        }
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,4 +1,5 @@
 use raw;
+use FingerList;
 use HandList;
 use InteractionBox;
 use PointableList;
@@ -14,6 +15,10 @@ impl Frame {
 
     pub fn current_fps(&self) -> f32 {
         unsafe { raw::lm_frame_current_frames_per_second(self.raw) }
+    }
+
+    pub fn fingers(&self) -> FingerList {
+        unsafe { FingerList::from_raw(raw::lm_frame_fingers(self.raw)) }
     }
 
     pub fn pointables(&self) -> PointableList {

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -64,6 +64,26 @@ impl HandList {
         }
     }
 
+    pub fn leftmost(&self) -> Option<Hand> {
+        unsafe {
+            if self.is_empty() {
+                None
+            } else {
+                Some(Hand::from_raw(raw::lm_hand_list_leftmost(self.raw)))
+            }
+        }
+    }
+
+    pub fn rightmost(&self) -> Option<Hand> {
+        unsafe {
+            if self.is_empty() {
+                None
+            } else {
+                Some(Hand::from_raw(raw::lm_hand_list_rightmost(self.raw)))
+            }
+        }
+    }
+
     pub fn get(&self, index: usize) -> Option<Hand> {
         unsafe {
             if index < self.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ pub mod raw;
 pub mod controller;
 pub use controller::Controller;
 
+pub mod finger;
+pub use finger::{Finger, FingerList};
+
 pub mod frame;
 pub use frame::Frame;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub mod controller;
 pub use controller::Controller;
 
 pub mod finger;
-pub use finger::{Finger, FingerList};
+pub use finger::{Finger, FingerList, FingerType};
 
 pub mod frame;
 pub use frame::Frame;

--- a/src/pointable.rs
+++ b/src/pointable.rs
@@ -23,6 +23,10 @@ impl Pointable {
     pub fn stabilized_tip_position(&self) -> Vector {
         unsafe { Vector::from_raw(raw::lm_pointable_stabilized_tip_position(self.raw)) }
     }
+
+    pub fn is_extended(&self) -> bool {
+        unsafe { raw::lm_pointable_is_extended(self.raw) }
+    }
 }
 
 impl Drop for Pointable {
@@ -48,6 +52,10 @@ impl PointableList {
 
     pub fn is_empty(&self) -> bool {
         unsafe { raw::lm_pointable_list_is_empty(self.raw) }
+    }
+
+    pub fn extended(&self) -> PointableList {
+        unsafe { PointableList::from_raw(raw::lm_pointable_list_extended(self.raw)) }
     }
 
     pub fn frontmost(&self) -> Option<Pointable> {

--- a/src/pointable.rs
+++ b/src/pointable.rs
@@ -62,6 +62,30 @@ impl PointableList {
         }
     }
 
+    pub fn leftmost(&self) -> Option<Pointable> {
+        unsafe {
+            if self.is_empty() {
+                None
+            } else {
+                Some(Pointable::from_raw(raw::lm_pointable_list_leftmost(
+                    self.raw,
+                )))
+            }
+        }
+    }
+
+    pub fn rightmost(&self) -> Option<Pointable> {
+        unsafe {
+            if self.is_empty() {
+                None
+            } else {
+                Some(Pointable::from_raw(raw::lm_pointable_list_rightmost(
+                    self.raw,
+                )))
+            }
+        }
+    }
+
     pub fn get(&self, index: usize) -> Option<Pointable> {
         unsafe {
             if index < self.len() {

--- a/src/raw/finger.rs
+++ b/src/raw/finger.rs
@@ -10,6 +10,7 @@ extern "C" {
     pub fn lm_finger_stabilized_tip_position(this: *mut Finger) -> *mut Vector;
     pub fn lm_finger_delete(this: *mut Finger);
     pub fn lm_finger_type(this: *mut Finger) -> u32;
+    pub fn lm_finger_is_extended(this: *mut Finger) -> bool;
     pub fn lm_finger_list_count(this: *mut FingerList) -> c_int;
     pub fn lm_finger_list_is_empty(this: *mut FingerList) -> bool;
     pub fn lm_finger_list_frontmost(this: *mut FingerList) -> *mut Finger;
@@ -17,4 +18,5 @@ extern "C" {
     pub fn lm_finger_list_rightmost(this: *mut FingerList) -> *mut Finger;
     pub fn lm_finger_list_delete(this: *mut FingerList);
     pub fn lm_finger_list_at(this: *mut FingerList, index: c_int) -> *mut Finger;
+    pub fn lm_finger_list_extended(this: *mut FingerList) -> *mut FingerList;
 }

--- a/src/raw/finger.rs
+++ b/src/raw/finger.rs
@@ -9,6 +9,7 @@ extern "C" {
     pub fn lm_finger_touch_distance(this: *mut Finger) -> c_float;
     pub fn lm_finger_stabilized_tip_position(this: *mut Finger) -> *mut Vector;
     pub fn lm_finger_delete(this: *mut Finger);
+    pub fn lm_finger_type(this: *mut Finger) -> u8;
     pub fn lm_finger_list_count(this: *mut FingerList) -> c_int;
     pub fn lm_finger_list_is_empty(this: *mut FingerList) -> bool;
     pub fn lm_finger_list_frontmost(this: *mut FingerList) -> *mut Finger;

--- a/src/raw/finger.rs
+++ b/src/raw/finger.rs
@@ -1,0 +1,15 @@
+use super::Vector;
+use std::os::raw::{c_float, c_int};
+
+pub enum Finger {}
+pub enum FingerList {}
+
+extern "C" {
+    pub fn lm_finger_id(this: *mut Finger) -> i32;
+    pub fn lm_finger_touch_distance(this: *mut Finger) -> c_float;
+    pub fn lm_finger_stabilized_tip_position(this: *mut Finger) -> *mut Vector;
+    pub fn lm_finger_delete(this: *mut Finger);
+    pub fn lm_finger_list_count(this: *mut FingerList) -> c_int;
+    pub fn lm_finger_list_delete(this: *mut FingerList);
+    pub fn lm_finger_list_at(this: *mut FingerList, index: c_int) -> *mut Finger;
+}

--- a/src/raw/finger.rs
+++ b/src/raw/finger.rs
@@ -10,6 +10,8 @@ extern "C" {
     pub fn lm_finger_stabilized_tip_position(this: *mut Finger) -> *mut Vector;
     pub fn lm_finger_delete(this: *mut Finger);
     pub fn lm_finger_list_count(this: *mut FingerList) -> c_int;
+    pub fn lm_finger_list_is_empty(this: *mut FingerList) -> bool;
+    pub fn lm_finger_list_frontmost(this: *mut FingerList) -> *mut Finger;
     pub fn lm_finger_list_delete(this: *mut FingerList);
     pub fn lm_finger_list_at(this: *mut FingerList, index: c_int) -> *mut Finger;
 }

--- a/src/raw/finger.rs
+++ b/src/raw/finger.rs
@@ -9,7 +9,7 @@ extern "C" {
     pub fn lm_finger_touch_distance(this: *mut Finger) -> c_float;
     pub fn lm_finger_stabilized_tip_position(this: *mut Finger) -> *mut Vector;
     pub fn lm_finger_delete(this: *mut Finger);
-    pub fn lm_finger_type(this: *mut Finger) -> u8;
+    pub fn lm_finger_type(this: *mut Finger) -> u32;
     pub fn lm_finger_list_count(this: *mut FingerList) -> c_int;
     pub fn lm_finger_list_is_empty(this: *mut FingerList) -> bool;
     pub fn lm_finger_list_frontmost(this: *mut FingerList) -> *mut Finger;

--- a/src/raw/finger.rs
+++ b/src/raw/finger.rs
@@ -18,5 +18,6 @@ extern "C" {
     pub fn lm_finger_list_rightmost(this: *mut FingerList) -> *mut Finger;
     pub fn lm_finger_list_delete(this: *mut FingerList);
     pub fn lm_finger_list_at(this: *mut FingerList, index: c_int) -> *mut Finger;
+    pub fn lm_finger_list_finger_type(this: *mut FingerList, finger_type: u32) -> *mut FingerList;
     pub fn lm_finger_list_extended(this: *mut FingerList) -> *mut FingerList;
 }

--- a/src/raw/finger.rs
+++ b/src/raw/finger.rs
@@ -12,6 +12,8 @@ extern "C" {
     pub fn lm_finger_list_count(this: *mut FingerList) -> c_int;
     pub fn lm_finger_list_is_empty(this: *mut FingerList) -> bool;
     pub fn lm_finger_list_frontmost(this: *mut FingerList) -> *mut Finger;
+    pub fn lm_finger_list_leftmost(this: *mut FingerList) -> *mut Finger;
+    pub fn lm_finger_list_rightmost(this: *mut FingerList) -> *mut Finger;
     pub fn lm_finger_list_delete(this: *mut FingerList);
     pub fn lm_finger_list_at(this: *mut FingerList, index: c_int) -> *mut Finger;
 }

--- a/src/raw/frame.rs
+++ b/src/raw/frame.rs
@@ -1,3 +1,4 @@
+use super::FingerList;
 use super::HandList;
 use super::InteractionBox;
 use super::PointableList;
@@ -8,6 +9,7 @@ pub enum Frame {}
 extern "C" {
     pub fn lm_frame_delete(this: *mut Frame);
     pub fn lm_frame_current_frames_per_second(this: *mut Frame) -> c_float;
+    pub fn lm_frame_fingers(this: *mut Frame) -> *mut FingerList;
     pub fn lm_frame_pointables(this: *mut Frame) -> *mut PointableList;
     pub fn lm_frame_hands(this: *mut Frame) -> *mut HandList;
     pub fn lm_frame_interaction_box(this: *mut Frame) -> *mut InteractionBox;

--- a/src/raw/hand.rs
+++ b/src/raw/hand.rs
@@ -13,6 +13,8 @@ extern "C" {
     pub fn lm_hand_list_count(this: *mut HandList) -> c_int;
     pub fn lm_hand_list_is_empty(this: *mut HandList) -> bool;
     pub fn lm_hand_list_frontmost(this: *mut HandList) -> *mut Hand;
+    pub fn lm_hand_list_leftmost(this: *mut HandList) -> *mut Hand;
+    pub fn lm_hand_list_rightmost(this: *mut HandList) -> *mut Hand;
     pub fn lm_hand_list_delete(this: *mut HandList);
     pub fn lm_hand_list_at(this: *mut HandList, index: c_int) -> *mut Hand;
 }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1,6 +1,9 @@
 pub mod controller;
 pub use self::controller::*;
 
+pub mod finger;
+pub use self::finger::*;
+
 pub mod frame;
 pub use self::frame::*;
 

--- a/src/raw/pointable.rs
+++ b/src/raw/pointable.rs
@@ -9,6 +9,7 @@ extern "C" {
     pub fn lm_pointable_touch_distance(this: *mut Pointable) -> c_float;
     pub fn lm_pointable_stabilized_tip_position(this: *mut Pointable) -> *mut Vector;
     pub fn lm_pointable_delete(this: *mut Pointable);
+    pub fn lm_pointable_is_extended(this: *mut Pointable) -> bool;
     pub fn lm_pointable_list_count(this: *mut PointableList) -> c_int;
     pub fn lm_pointable_list_is_empty(this: *mut PointableList) -> bool;
     pub fn lm_pointable_list_frontmost(this: *mut PointableList) -> *mut Pointable;
@@ -16,4 +17,5 @@ extern "C" {
     pub fn lm_pointable_list_rightmost(this: *mut PointableList) -> *mut Pointable;
     pub fn lm_pointable_list_delete(this: *mut PointableList);
     pub fn lm_pointable_list_at(this: *mut PointableList, index: c_int) -> *mut Pointable;
+    pub fn lm_pointable_list_extended(this: *mut PointableList) -> *mut PointableList;
 }

--- a/src/raw/pointable.rs
+++ b/src/raw/pointable.rs
@@ -12,6 +12,8 @@ extern "C" {
     pub fn lm_pointable_list_count(this: *mut PointableList) -> c_int;
     pub fn lm_pointable_list_is_empty(this: *mut PointableList) -> bool;
     pub fn lm_pointable_list_frontmost(this: *mut PointableList) -> *mut Pointable;
+    pub fn lm_pointable_list_leftmost(this: *mut PointableList) -> *mut Pointable;
+    pub fn lm_pointable_list_rightmost(this: *mut PointableList) -> *mut Pointable;
     pub fn lm_pointable_list_delete(this: *mut PointableList);
     pub fn lm_pointable_list_at(this: *mut PointableList, index: c_int) -> *mut Pointable;
 }

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -8,6 +8,7 @@ set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_library (leap_motion_wrapper STATIC
     controller.cpp
+    finger.cpp
     frame.cpp
     pointable.cpp
     vector.cpp

--- a/wrapper/finger.cpp
+++ b/wrapper/finger.cpp
@@ -29,6 +29,10 @@ extern "C" {
         return self->isExtended();
     }
 
+    LM_FingerList lm_finger_list_finger_type(LM_FingerList self, uint32_t type) {
+        return new Leap::FingerList(self->fingerType((Leap::Finger::Type) type));
+    }
+
     LM_FingerList lm_finger_list_extended(LM_FingerList self) {
         return new Leap::FingerList(self->extended());
     }

--- a/wrapper/finger.cpp
+++ b/wrapper/finger.cpp
@@ -1,0 +1,38 @@
+#include <cstdint>
+#include <Leap.h>
+#include "finger.h"
+#include "vector.h"
+#include "list.h"
+
+extern "C" {
+    int32_t lm_finger_id(LM_Finger self) {
+        return self->id();
+    }
+
+    float lm_finger_touch_distance(LM_Finger self) {
+        return self->touchDistance();
+    }
+
+    LM_Vector lm_finger_stabilized_tip_position(LM_Finger self) {
+        return new Leap::Vector(self->stabilizedTipPosition());
+    }
+
+    void lm_finger_delete(LM_Finger self) {
+        delete self;
+    }
+
+    // TODO: int lm_finger_list_count(LM_FingerList self) {
+    // TODO:     return 5;
+    // TODO: }
+
+    void lm_finger_list_delete(LM_FingerList self) {
+        delete self;
+    }
+
+    // TODO: LM_Finger _finger_list_at(LM_FingerList self, int index) {
+    // TODO:     return new Leap::Finger(self[index]);
+    // TODO: }
+
+    // LM_LIST_IMPL(Finger, finger)
+    // LM_LIST_SPATIAL_IMPL(Finger, finger)
+}

--- a/wrapper/finger.cpp
+++ b/wrapper/finger.cpp
@@ -21,6 +21,10 @@ extern "C" {
         delete self;
     }
 
+    int8_t lm_finger_type(LM_Finger self) {
+        return self->type();
+    }
+
     LM_LIST_IMPL(Finger, finger)
     LM_LIST_SPATIAL_IMPL(Finger, finger)
 }

--- a/wrapper/finger.cpp
+++ b/wrapper/finger.cpp
@@ -21,7 +21,7 @@ extern "C" {
         delete self;
     }
 
-    int8_t lm_finger_type(LM_Finger self) {
+    uint32_t lm_finger_type(LM_Finger self) {
         return self->type();
     }
 

--- a/wrapper/finger.cpp
+++ b/wrapper/finger.cpp
@@ -21,18 +21,6 @@ extern "C" {
         delete self;
     }
 
-    // TODO: int lm_finger_list_count(LM_FingerList self) {
-    // TODO:     return 5;
-    // TODO: }
-
-    void lm_finger_list_delete(LM_FingerList self) {
-        delete self;
-    }
-
-    // TODO: LM_Finger _finger_list_at(LM_FingerList self, int index) {
-    // TODO:     return new Leap::Finger(self[index]);
-    // TODO: }
-
-    // LM_LIST_IMPL(Finger, finger)
-    // LM_LIST_SPATIAL_IMPL(Finger, finger)
+    LM_LIST_IMPL(Finger, finger)
+    LM_LIST_SPATIAL_IMPL(Finger, finger)
 }

--- a/wrapper/finger.cpp
+++ b/wrapper/finger.cpp
@@ -25,6 +25,14 @@ extern "C" {
         return self->type();
     }
 
+    bool lm_finger_is_extended(LM_Finger self) {
+        return self->isExtended();
+    }
+
+    LM_FingerList lm_finger_list_extended(LM_FingerList self) {
+        return new Leap::FingerList(self->extended());
+    }
+
     LM_LIST_IMPL(Finger, finger)
     LM_LIST_SPATIAL_IMPL(Finger, finger)
 }

--- a/wrapper/finger.cpp
+++ b/wrapper/finger.cpp
@@ -5,38 +5,15 @@
 #include "list.h"
 
 extern "C" {
-    int32_t lm_finger_id(LM_Finger self) {
-        return self->id();
-    }
-
-    float lm_finger_touch_distance(LM_Finger self) {
-        return self->touchDistance();
-    }
-
-    LM_Vector lm_finger_stabilized_tip_position(LM_Finger self) {
-        return new Leap::Vector(self->stabilizedTipPosition());
-    }
-
-    void lm_finger_delete(LM_Finger self) {
-        delete self;
-    }
-
     uint32_t lm_finger_type(LM_Finger self) {
         return self->type();
-    }
-
-    bool lm_finger_is_extended(LM_Finger self) {
-        return self->isExtended();
     }
 
     LM_FingerList lm_finger_list_finger_type(LM_FingerList self, uint32_t type) {
         return new Leap::FingerList(self->fingerType((Leap::Finger::Type) type));
     }
 
-    LM_FingerList lm_finger_list_extended(LM_FingerList self) {
-        return new Leap::FingerList(self->extended());
-    }
-
     LM_LIST_IMPL(Finger, finger)
     LM_LIST_SPATIAL_IMPL(Finger, finger)
+    LM_LIST_TIPPED_IMPL(Finger, finger)
 }

--- a/wrapper/finger.h
+++ b/wrapper/finger.h
@@ -1,0 +1,8 @@
+#ifndef LM_FINGER_H
+#define LM_FINGER_H
+#include <Leap.h>
+
+typedef Leap::Finger* LM_Finger;
+typedef Leap::FingerList* LM_FingerList;
+
+#endif

--- a/wrapper/frame.cpp
+++ b/wrapper/frame.cpp
@@ -1,5 +1,6 @@
 #include <Leap.h>
 #include "frame.h"
+#include "finger.h"
 #include "pointable.h"
 #include "hand.h"
 #include "interaction_box.h"
@@ -11,6 +12,10 @@ extern "C" {
 
     float lm_frame_current_frames_per_second(LM_Frame self) {
         return self->currentFramesPerSecond();
+    }
+
+    LM_FingerList lm_frame_fingers(LM_Frame self) {
+        return new Leap::FingerList(self->fingers());
     }
 
     LM_PointableList lm_frame_pointables(LM_Frame self) {

--- a/wrapper/hand.cpp
+++ b/wrapper/hand.cpp
@@ -1,6 +1,7 @@
 #include <cstdint>
 #include <Leap.h>
 #include "hand.h"
+#include "finger.h"
 #include "vector.h"
 #include "list.h"
 
@@ -8,6 +9,10 @@ extern "C" {
     int32_t lm_hand_id(LM_Hand self) {
         return self->id();
     }
+
+    /* LM_FingerList lm_frame_fingers(LM_Hand self) { */
+    /*     return new Leap::FingerList(self->fingers()); */
+    /* } */
 
     float lm_hand_pinch_distance(LM_Hand self) {
         // TODO: use pinchDistance() once Leap SDK 3.x releases

--- a/wrapper/list.h
+++ b/wrapper/list.h
@@ -35,4 +35,31 @@
         } \
     }
 
+#define LM_LIST_TIPPED_IMPL(TYPE, IDENT) \
+    extern "C" {                                                     \
+        int32_t lm_##IDENT##_id(LM_##TYPE self) { \
+            return self->id(); \
+        } \
+        \
+        float lm_##IDENT##_touch_distance(LM_##TYPE self) { \
+            return self->touchDistance(); \
+        } \
+        \
+        void lm_##IDENT##_delete(LM_##TYPE self) { \
+            delete self; \
+        } \
+        \
+        LM_Vector lm_##IDENT##_stabilized_tip_position(LM_##TYPE self) { \
+            return new Leap::Vector(self->stabilizedTipPosition()); \
+        } \
+        \
+        bool lm_##IDENT##_is_extended(LM_##TYPE self) { \
+            return self->isExtended(); \
+        } \
+        \
+        LM_##TYPE##List lm_##IDENT##_list_extended(LM_##TYPE##List self) { \
+            return new Leap::TYPE##List(self->extended()); \
+        } \
+    }
+
 #endif

--- a/wrapper/list.h
+++ b/wrapper/list.h
@@ -25,6 +25,14 @@
         LM_##TYPE lm_##IDENT##_list_frontmost(LM_##TYPE##List self) { \
             return new Leap::TYPE(self->frontmost()); \
         } \
+        \
+        LM_##TYPE lm_##IDENT##_list_leftmost(LM_##TYPE##List self) { \
+            return new Leap::TYPE(self->leftmost()); \
+        } \
+        \
+        LM_##TYPE lm_##IDENT##_list_rightmost(LM_##TYPE##List self) { \
+            return new Leap::TYPE(self->rightmost()); \
+        } \
     }
 
 #endif

--- a/wrapper/pointable.cpp
+++ b/wrapper/pointable.cpp
@@ -21,6 +21,14 @@ extern "C" {
         delete self;
     }
 
+    bool lm_pointable_is_extended(LM_Pointable self) {
+        return self->isExtended();
+    }
+
+    LM_PointableList lm_pointable_list_extended(LM_PointableList self) {
+        return new Leap::PointableList(self->extended());
+    }
+
     LM_LIST_IMPL(Pointable, pointable)
     LM_LIST_SPATIAL_IMPL(Pointable, pointable)
 }

--- a/wrapper/pointable.cpp
+++ b/wrapper/pointable.cpp
@@ -5,30 +5,7 @@
 #include "list.h"
 
 extern "C" {
-    int32_t lm_pointable_id(LM_Pointable self) {
-        return self->id();
-    }
-
-    float lm_pointable_touch_distance(LM_Pointable self) {
-        return self->touchDistance();
-    }
-
-    LM_Vector lm_pointable_stabilized_tip_position(LM_Pointable self) {
-        return new Leap::Vector(self->stabilizedTipPosition());
-    }
-
-    void lm_pointable_delete(LM_Pointable self) {
-        delete self;
-    }
-
-    bool lm_pointable_is_extended(LM_Pointable self) {
-        return self->isExtended();
-    }
-
-    LM_PointableList lm_pointable_list_extended(LM_PointableList self) {
-        return new Leap::PointableList(self->extended());
-    }
-
     LM_LIST_IMPL(Pointable, pointable)
     LM_LIST_SPATIAL_IMPL(Pointable, pointable)
+    LM_LIST_TIPPED_IMPL(Pointable, pointable)
 }


### PR DESCRIPTION
This implements various finger related constructs and methods. The listener example has been extended.

Not all finger methods have are included. I might implement some more as required for a project I'm working on.